### PR TITLE
Issue #4: Add gRPC video ingestion service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,8 @@ htmlcov/
 replication_pb2.py
 replication_pb2_grpc.py
 replication_pb2.pyi
+client_master_pb2.py
+client_master_pb2_grpc.py
 
 # Generated video shard directories
 video_shards/

--- a/Master/client_master.proto
+++ b/Master/client_master.proto
@@ -1,0 +1,19 @@
+syntax = "proto3";
+
+package clientmaster;
+
+// Service for uploading an entire video stream from a client
+service ClientUploadService {
+  // Client streams chunks of the video; master returns a final acknowledgement
+  rpc UploadVideo(stream VideoChunk) returns (UploadResponse);
+}
+
+message VideoChunk {
+  string video_name = 1;  // original filename
+  bytes  data       = 2;  // raw bytes
+}
+
+message UploadResponse {
+  bool   success = 1;
+  string message = 2;
+}

--- a/Master/start_master.sh
+++ b/Master/start_master.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
+# To run as ingestion server: ./start_master.sh --serve
 python3 master.py --video_path ./sample_videos/file_example_MP4_1920_18MG.mp4 --workers localhost:50061,localhost:50062


### PR DESCRIPTION
## Summary

This PR implements **Issue #4: Master – Data/Video Ingestion** by adding a gRPC-based video upload endpoint to the Master. Clients can now stream an entire video file chunk-by-chunk over gRPC. Once received, the Master saves the file and immediately invokes the existing `distribute_video_to_workers` pipeline.

---

## What’s Changed

- **`Master/client_master.proto`**  
  - Defines `ClientUploadService.UploadVideo(stream VideoChunk) → UploadResponse`.

- **Generated gRPC stubs in `Master/`**  
  - `client_master_pb2.py` & `client_master_pb2_grpc.py`  
  - **Regenerated** `replication_pb2.py` & `replication_pb2_grpc.py` in `Master/` for local imports.

- **`Master/client_upload.py`**  
  - CLI client script that reads `--video_path` in 1 MB chunks and streams them to the Master’s ingestion server.

- **`Master/master.py`**  
  - Imports and registers `ClientUploadService` alongside existing replication logic.  
  - Adds `serve_ingestion()` and a new `--serve` flag to run in **ingestion mode**.  
  - Makes `--video_path` optional, enforcing it only when **not** in `--serve` mode.  
  - Uses a module-level `worker_addresses` list so both `main()` and the upload handler share the same worker list.


---

## How to Test

1. **Start two Worker instances** (or mocks) on ports `50061` and `50062`.
2. **Run the Master in ingestion mode**:  
   ```bash
   cd Master
   python3 master.py \
     --workers localhost:50061,localhost:50062 \
     --serve